### PR TITLE
Remove comment from POSTGRES_PASSWORD value

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ CONF_PATH=conf
 
 ##
 # Duplication of application Database config for docker(compose) local development
-POSTGRES_DB=postgres   # Same as DB_NAME
-POSTGRES_USER=postgres # Same as DB_USER
-POSTGRES_PASSWORD=this-is-not-secure # Same as DB_PASSWORD
+# Same as DB_NAME:
+POSTGRES_DB=postgres
+# Same as DB_USER:
+POSTGRES_USER=postgres
+# Same as DB_PASSWORD:
+POSTGRES_PASSWORD=this-is-not-secure

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker run -t -i \
     postgres:16-bookworm
 ```
 
-Make sure to replace the `POSTGRES_PASSWORD` and the `<veramo-agent-path>` with proper values and in general match the vales with the `.env` or `.env.local` configuration.
+Make sure to replace the `<veramo-agent-path>` with a full filesystem path and in your `.env` file, make sure the values of `DB_PASSWORD` and `POSTGRES_PASSWORD` match.
 
 ### OpenObserver
 


### PR DESCRIPTION
The comment in the .env file had an undesired side-effect:
```
$ docker exec -it magical_nash env
[...]
POSTGRES_PASSWORD=this-is-not-secure # Same as DB_PASSWORD
```

This also fixes the instructions about values to replace in the docker command.